### PR TITLE
update to gradle 1.0.0

### DIFF
--- a/Something/build.gradle
+++ b/Something/build.gradle
@@ -41,15 +41,14 @@ android {
 
         release {
             debuggable false
-            runProguard false
+            minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
             signingConfig signingConfigs.somethingKey
-        }
-
-        applicationVariants.all { variant ->
-            if(variant.buildType.name == 'release'){
-                def file = variant.outputFile
-                variant.outputFile = new File(file.parent, file.name.replace(".apk", "-" + defaultConfig.versionName + "-" + rootProject.versionCode+ ".apk"))
+            applicationVariants.all { variant ->
+                variant.outputs.each { output ->
+                    def file = output.outputFile
+                    output.outputFile = new File(file.parent, file.name.replace(".apk", "-" + defaultConfig.versionName + "-" + rootProject.versionCode+ ".apk"))
+                }
             }
         }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         maven { url 'http://gradle.bugsense.com/' }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.13.2'
+        classpath 'com.android.tools.build:gradle:1.0.0'
     }
 }
 


### PR DESCRIPTION
Newest version of Android Studio/intellij complains about outdated version of gradle (and will error when attempting to build using suggested settings).

This seems to work fine for me (gradle installed properly, built to phone, app seems to work as expected).