### PR TITLE
Fix BYOB threads not loading

### DIFF
--- a/Something/src/main/java/net/fastfourier/something/request/ThreadPageRequest.java
+++ b/Something/src/main/java/net/fastfourier/something/request/ThreadPageRequest.java
@@ -169,7 +169,7 @@ public class ThreadPageRequest extends HTMLRequest<ThreadPageRequest.ThreadPage>
         }
     }
 
-    private static Pattern userJumpPattern = Pattern.compile("userid-(\\d+)");
+    private static Pattern userJumpPattern = Pattern.compile("userid=(\\d+)");
 
     private static int parsePosts(Document doc, ArrayList<HashMap<String, String>> postArray, boolean showImages, boolean showAvatars, boolean hideSeenImages, String unreadPti, boolean canReply, boolean lastPage, int forumId){
         int unread = 0;
@@ -194,8 +194,8 @@ public class ThreadPageRequest extends HTMLRequest<ThreadPageRequest.ThreadPage>
 
                 boolean editable = post.getElementsByAttributeValueContaining("href","editpost.php?action=editpost").size() > 0;
 
-                Element userInfo = post.getElementsByClass("userinfo").first();
-                Matcher userIdMatcher = userJumpPattern.matcher(userInfo.attr("class"));
+                Element userInfo = post.getElementsByClass("user_jump").first();
+                Matcher userIdMatcher = userJumpPattern.matcher(userInfo.attr("href"));
                 String userId = null;
                 if(userIdMatcher.find()){
                     userId = userIdMatcher.group(1);


### PR DESCRIPTION
davidcbc changed the regex on his filter by user update to use
something that all forums have except BYOB, which then caused an
exception to be constantly thrown for any request made on it.