### PR TITLE
Fix filter by user

### DIFF
--- a/Something/src/main/java/net/fastfourier/something/request/ThreadPageRequest.java
+++ b/Something/src/main/java/net/fastfourier/something/request/ThreadPageRequest.java
@@ -194,7 +194,7 @@ public class ThreadPageRequest extends HTMLRequest<ThreadPageRequest.ThreadPage>
 
                 boolean editable = post.getElementsByAttributeValueContaining("href","editpost.php?action=editpost").size() > 0;
 
-                Element userInfo = post.getElementsByClass("user_jump").first();
+                Element userInfo = post.getElementsByClass("profilelinks").first().getElementsByTag("a").first();
                 Matcher userIdMatcher = userJumpPattern.matcher(userInfo.attr("href"));
                 String userId = null;
                 if(userIdMatcher.find()){


### PR DESCRIPTION
Turns out I broke filter by user with the last pull request because the 'user_jump' on that page only points back to the postid. I think that the little profile button actually does appear on every page is always the same and usable.